### PR TITLE
Small markdown error fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ work similarly on both iOS & Android:
 >
 > Example cross-platform configuration:
 >
-> ```json
+```json 
 {
   "android": {
     "requiredUpdate": {


### PR DESCRIPTION
The Readme got all weird due to a misplaced `>` this fixes that.