### PR TITLE
Updating Travis CI config to keep CI jobs working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
     - develop
     - master
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 notifications:
   slack:
     rooms:
@@ -14,8 +14,9 @@ notifications:
     on_success: change
 before_install:
   - rvm use $RVM_RUBY_VERSION
-  - gem install cocoapods
+  - bundle
   - gem install slather
+  - pod repo update
   - pod install
 after_success:
   - slather


### PR DESCRIPTION
Updating to oldest version of Xcode that is not (yet) deprecated by Travis CI.
Also, using bundler to install CocoaPods.