### PR TITLE
Resolve info.plist collision build error

### DIFF
--- a/LaunchGate.podspec
+++ b/LaunchGate.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/dtrenz'
   s.platform         = :ios, '8.3'
   s.requires_arc     = true
-  s.source_files     = 'Source/**/*'
+  s.source_files     = 'Source/**/*.swift'
   s.frameworks       = 'UIKit'
   s.swift_version    = '4.1'
 end


### PR DESCRIPTION
**Issue**
Currently after this pod is installed, the following build error is encountered. 

<img width="1584" alt="screen shot 2018-07-26 at 3 29 22 pm" src="https://user-images.githubusercontent.com/40871611/43284134-e168226c-90e8-11e8-9387-1bf94b37428b.png">

Looks like its including the info.plist file which is causing issues when building the project.

**Files in question**
<img width="310" alt="screen shot 2018-07-26 at 3 12 11 pm" src="https://user-images.githubusercontent.com/40871611/43283262-6bd40b4e-90e6-11e8-9628-5e409365d8f6.png">

**Proposed change**
By adding .swift to the pod spec file. When the pod is installed the info.plist and the unnecessary header file will be excluded.

I can work around the problem locally, the main issue is, Jenkins is getting the same build error.