### PR TITLE
Updating to JSONDecoder from JSONSerialization

### DIFF
--- a/Example/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -39,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/LaunchGate.xcodeproj/project.pbxproj
+++ b/LaunchGate.xcodeproj/project.pbxproj
@@ -504,6 +504,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -555,6 +556,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -579,7 +581,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -599,7 +600,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.dtrenz.LaunchGate;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -611,7 +611,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dtrenz.LaunchGateTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -623,7 +622,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dtrenz.LaunchGateTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/LaunchGate.xcodeproj/xcshareddata/xcschemes/LaunchGate.xcscheme
+++ b/LaunchGate.xcodeproj/xcshareddata/xcschemes/LaunchGate.xcscheme
@@ -43,10 +43,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "C5C04BC51C696767007397D0"
-            BuildableName = "LaunchGate.framework"
-            BlueprintName = "LaunchGate"
-            ReferencedContainer = "container:LaunchGate.xcodeproj">
+            BlueprintIdentifier = "C5A878881C6A7A95004599C2"
+            BuildableName = "Example.app"
+            BlueprintName = "Example"
+            ReferencedContainer = "container:Example/Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
@@ -62,15 +62,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "C5C04BC51C696767007397D0"
-            BuildableName = "LaunchGate.framework"
-            BlueprintName = "LaunchGate"
-            ReferencedContainer = "container:LaunchGate.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-pod 'SwiftLint'
-
 target 'LaunchGateTests' do
   platform :ios, '8.3'
   inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Nimble (7.1.3)
-  - Quick (1.3.1)
-  - SwiftLint (0.26.0)
+  - Nimble (7.3.1)
+  - Quick (1.3.2)
+  - SwiftLint (0.27.0)
 
 DEPENDENCIES:
   - Nimble
@@ -15,10 +15,10 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  Nimble: 2839b01d1b31f6a6a7777a221f0d91cf52e8e27b
-  Quick: d17304d58d0d169dd0bd1c6e5c28e3318de32a1a
-  SwiftLint: f6b83e8d95ee1e91e11932d843af4fdcbf3fc764
+  Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
+  Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
+  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
 
-PODFILE CHECKSUM: 80b19f99959846e7855de4619381077e49a4e498
+PODFILE CHECKSUM: c66a903b4dd3d64e68e8dcb4170d38ac84ba0147
 
 COCOAPODS: 1.5.3

--- a/Source/AlertConfiguration.swift
+++ b/Source/AlertConfiguration.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class AlertConfiguration: Decodable, Dialogable, Rememberable {
+public struct AlertConfiguration: Decodable, Dialogable, Rememberable {
 
     let message: String
     let blocking: Bool

--- a/Source/AlertConfiguration.swift
+++ b/Source/AlertConfiguration.swift
@@ -9,8 +9,8 @@ import Foundation
 
 public struct AlertConfiguration: Decodable, Dialogable, Rememberable {
 
-    let message: String?
-    let blocking: Bool?
+    let message: String
+    let blocking: Bool
 
   init?(message: String, blocking: Bool) {
     guard !message.isEmpty else { return nil }
@@ -26,7 +26,7 @@ public struct AlertConfiguration: Decodable, Dialogable, Rememberable {
   }
 
   func rememberString() -> String {
-    return self.message! ///unwrap
+    return self.message
   }
 
 }

--- a/Source/AlertConfiguration.swift
+++ b/Source/AlertConfiguration.swift
@@ -9,8 +9,8 @@ import Foundation
 
 public struct AlertConfiguration: Decodable, Dialogable, Rememberable {
 
-    let message: String
-    let blocking: Bool
+    let message: String?
+    let blocking: Bool?
 
   init?(message: String, blocking: Bool) {
     guard !message.isEmpty else { return nil }
@@ -26,7 +26,7 @@ public struct AlertConfiguration: Decodable, Dialogable, Rememberable {
   }
 
   func rememberString() -> String {
-    return self.message
+    return self.message! ///unwrap
   }
 
 }

--- a/Source/AlertConfiguration.swift
+++ b/Source/AlertConfiguration.swift
@@ -7,10 +7,10 @@
 
 import Foundation
 
-public struct AlertConfiguration: Dialogable, Rememberable {
+public struct AlertConfiguration: Decodable, Dialogable, Rememberable {
 
-  var message = ""
-  var blocking = false
+    let message: String
+    let blocking: Bool
 
   init?(message: String, blocking: Bool) {
     guard !message.isEmpty else { return nil }

--- a/Source/AlertConfiguration.swift
+++ b/Source/AlertConfiguration.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct AlertConfiguration: Decodable, Dialogable, Rememberable {
+public class AlertConfiguration: Decodable, Dialogable, Rememberable {
 
     let message: String
     let blocking: Bool

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -50,27 +50,21 @@ class DefaultParser: LaunchGateParser {
       var alert: AlertConfiguration?
       var optionalUpdate: UpdateConfiguration?
       var requiredUpdate: UpdateConfiguration?
-
-        guard let alertJSON = config["alert"] as? Data else {
-            print("No alert")
-            return nil }
+        
+      if let alertJSON = config["alert"] as? JSON {
         alert = try DefaultParser.parseAlert(alertJSON)
         print("Alert: \(alert!)")
-      
+      }
 
-      guard let optionalUpdateJSON = config["optionalUpdate"] as? Data else {
-        print("No optional update")
-        return nil }
+      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
         optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
         print("Optional Update: \(optionalUpdate!)")
-      
+      }
 
-      guard let requiredUpdateJSON = config["requiredUpdate"] as? Data else {
-        print("No required update")
-        return nil }
+      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
         requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
         print("Required Update: \(requiredUpdate!)")
-      
+      }
 
       return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
     } catch let error as DefaultParser.Error {
@@ -86,56 +80,56 @@ class DefaultParser: LaunchGateParser {
     return nil
   }
 //   --- Experiments ---
-    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
-        do {
-            let decoder = JSONDecoder()
-            let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
-            return result
-        } catch {
-            print(error)
-            return nil
-        }
-    }
-    private static func parseOptionalUpdate(_ jsonData: Data) -> UpdateConfiguration? {
-        do {
-            let decoder = JSONDecoder()
-            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
-            return result
-        } catch {
-            print(error)
-            return nil
-        }
-    }
-    private static func parseRequiredUpdate(_ jsonData: Data) -> UpdateConfiguration? {
-        do {
-            let decoder = JSONDecoder()
-            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
-            return result
-        } catch {
-            print(error)
-            return nil
-        }
-    }
+//    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
+//        do {
+//            let decoder = JSONDecoder()
+//            let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
+//            return result
+//        } catch {
+//            print(error)
+//            return nil
+//        }
+//    }
+//    private static func parseOptionalUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+//        do {
+//            let decoder = JSONDecoder()
+//            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+//            return result
+//        } catch {
+//            print(error)
+//            return nil
+//        }
+//    }
+//    private static func parseRequiredUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+//        do {
+//            let decoder = JSONDecoder()
+//            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+//            return result
+//        } catch {
+//            print(error)
+//            return nil
+//        }
+//    }
 //  --- End of Experiments ---
-//  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
-//    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
-//    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }
-//
-//    return AlertConfiguration(message: message, blocking: blocking)
-//  }
-//
-//  private static func parseOptionalUpdate(_ json: JSON) throws -> UpdateConfiguration? {
-//    guard let version = json["optionalVersion"] as? String else { throw Error.unableToParseOptionalUpdate }
-//    guard let message = json["message"] as? String else { throw Error.unableToParseOptionalUpdate }
-//
-//    return UpdateConfiguration(version: version, message: message)
-//  }
-//
-//  private static func parseRequiredUpdate(_ json: JSON) throws -> UpdateConfiguration? {
-//    guard let version = json["minimumVersion"] as? String else { throw Error.unableToParseRequiredUpdate }
-//    guard let message = json["message"] as? String else { throw Error.unableToParseRequiredUpdate }
-//
-//    return UpdateConfiguration(version: version, message: message)
-//  }
+  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
+    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
+    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }
+
+    return AlertConfiguration(message: message, blocking: blocking)
+  }
+
+  private static func parseOptionalUpdate(_ json: JSON) throws -> UpdateConfiguration? {
+    guard let version = json["optionalVersion"] as? String else { throw Error.unableToParseOptionalUpdate }
+    guard let message = json["message"] as? String else { throw Error.unableToParseOptionalUpdate }
+
+    return UpdateConfiguration(version: version, message: message)
+  }
+
+  private static func parseRequiredUpdate(_ json: JSON) throws -> UpdateConfiguration? {
+    guard let version = json["minimumVersion"] as? String else { throw Error.unableToParseRequiredUpdate }
+    guard let message = json["message"] as? String else { throw Error.unableToParseRequiredUpdate }
+
+    return UpdateConfiguration(version: version, message: message)
+  }
 
 }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -75,7 +75,7 @@ class DefaultParser: LaunchGateParser {
 //
 //    return nil
 //  }
-//
+//   --- Experiments ---
 //    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
 //        do {
 //            let decoder = JSONDecoder()
@@ -106,6 +106,7 @@ class DefaultParser: LaunchGateParser {
 //            return nil
 //        }
 //    }
+//  --- End of Experiments ---
 //  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
 //    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
 //    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -40,45 +40,45 @@ class DefaultParser: LaunchGateParser {
 //        }
 //        return nil
 //    }
-  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
-    do {
-        print("Parsing...")
-        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
-      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
-      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
-
-      var alert: AlertConfiguration?
-      var optionalUpdate: UpdateConfiguration?
-      var requiredUpdate: UpdateConfiguration?
-        
-      if let alertJSON = config["alert"] as? JSON {
-        alert = try DefaultParser.parseAlert(alertJSON)
-        print("Alert: \(alert!)")
-      }
-
-      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
-        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
-        print("Optional Update: \(optionalUpdate!)")
-      }
-
-      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
-        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
-        print("Required Update: \(requiredUpdate!)")
-      }
-
-      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
-    } catch let error as DefaultParser.Error {
-      print("LaunchGate — Error: \(error)")
-    } catch let error as NSError {
-      print("LaunchGate — Error: \(error.localizedDescription)")
-
-      if let recoverySuggestion = error.localizedRecoverySuggestion {
-        print(recoverySuggestion)
-      }
-    }
-
-    return nil
-  }
+//  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+//    do {
+//        print("Parsing...")
+//        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
+//      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
+//      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
+//
+//      var alert: AlertConfiguration?
+//      var optionalUpdate: UpdateConfiguration?
+//      var requiredUpdate: UpdateConfiguration?
+//
+//      if let alertJSON = config["alert"] as? JSON {
+//        alert = try DefaultParser.parseAlert(alertJSON)
+//        print("Alert: \(alert!)")
+//      }
+//
+//      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
+//        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
+//        print("Optional Update: \(optionalUpdate!)")
+//      }
+//
+//      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
+//        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
+//        print("Required Update: \(requiredUpdate!)")
+//      }
+//
+//      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
+//    } catch let error as DefaultParser.Error {
+//      print("LaunchGate — Error: \(error)")
+//    } catch let error as NSError {
+//      print("LaunchGate — Error: \(error.localizedDescription)")
+//
+//      if let recoverySuggestion = error.localizedRecoverySuggestion {
+//        print(recoverySuggestion)
+//      }
+//    }
+//
+//    return nil
+//  }
 //   --- Experiments ---
 //    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
 //        do {
@@ -111,25 +111,25 @@ class DefaultParser: LaunchGateParser {
 //        }
 //    }
 //  --- End of Experiments ---
-  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
-    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
-    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }
-
-    return AlertConfiguration(message: message, blocking: blocking)
-  }
-
-  private static func parseOptionalUpdate(_ json: JSON) throws -> UpdateConfiguration? {
-    guard let version = json["optionalVersion"] as? String else { throw Error.unableToParseOptionalUpdate }
-    guard let message = json["message"] as? String else { throw Error.unableToParseOptionalUpdate }
-
-    return UpdateConfiguration(version: version, message: message)
-  }
-
-  private static func parseRequiredUpdate(_ json: JSON) throws -> UpdateConfiguration? {
-    guard let version = json["minimumVersion"] as? String else { throw Error.unableToParseRequiredUpdate }
-    guard let message = json["message"] as? String else { throw Error.unableToParseRequiredUpdate }
-
-    return UpdateConfiguration(version: version, message: message)
-  }
+//  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
+//    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
+//    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }
+//
+//    return AlertConfiguration(message: message, blocking: blocking)
+//  }
+//
+//  private static func parseOptionalUpdate(_ json: JSON) throws -> UpdateConfiguration? {
+//    guard let version = json["optionalVersion"] as? String else { throw Error.unableToParseOptionalUpdate }
+//    guard let message = json["message"] as? String else { throw Error.unableToParseOptionalUpdate }
+//
+//    return UpdateConfiguration(version: version, message: message)
+//  }
+//
+//  private static func parseRequiredUpdate(_ json: JSON) throws -> UpdateConfiguration? {
+//    guard let version = json["minimumVersion"] as? String else { throw Error.unableToParseRequiredUpdate }
+//    guard let message = json["message"] as? String else { throw Error.unableToParseRequiredUpdate }
+//
+//    return UpdateConfiguration(version: version, message: message)
+//  }
 
 }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -50,7 +50,7 @@ class DefaultParser: LaunchGateParser {
 //      var optionalUpdate: UpdateConfiguration?
 //      var requiredUpdate: UpdateConfiguration?
 //
-//      if let alertJSON = config["alert"] /*as? JSON*/ {
+//      if let alertJSON = config["alert"] as? JSON {
 //        alert = try DefaultParser.parseAlert(alertJSON)
 //      }
 //

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -9,27 +9,7 @@
 import Foundation
 
 class DefaultParser: LaunchGateParser {
-  typealias JSON = [String: AnyObject]
 
-  enum Error: LaunchGateError {
-    case unableToParseConfigurationObject
-    case unableToParseAlert
-    case unableToParseOptionalUpdate
-    case unableToParseRequiredUpdate
-
-    var description: String {
-        switch self {
-        case .unableToParseConfigurationObject:
-            return "Unable to parse the configuration object (\"ios\") from JSON file."
-        case .unableToParseAlert:
-            return "Unable to parse the alert configuration from JSON file."
-        case .unableToParseOptionalUpdate:
-            return "Unable to parse the optional update configuration from JSON file."
-        case .unableToParseRequiredUpdate:
-            return "Unable to parse the required update configuration from JSON file."
-        }
-    }
-    }
     func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
         do {
             let decoder = JSONDecoder()
@@ -40,96 +20,4 @@ class DefaultParser: LaunchGateParser {
         }
         return nil
     }
-//  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
-//    do {
-//        print("Parsing...")
-//        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
-//      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
-//      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
-//
-//      var alert: AlertConfiguration?
-//      var optionalUpdate: UpdateConfiguration?
-//      var requiredUpdate: UpdateConfiguration?
-//
-//      if let alertJSON = config["alert"] as? JSON {
-//        alert = try DefaultParser.parseAlert(alertJSON)
-//        print("Alert: \(alert!)")
-//      }
-//
-//      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
-//        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
-//        print("Optional Update: \(optionalUpdate!)")
-//      }
-//
-//      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
-//        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
-//        print("Required Update: \(requiredUpdate!)")
-//      }
-//
-//      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
-//    } catch let error as DefaultParser.Error {
-//      print("LaunchGate — Error: \(error)")
-//    } catch let error as NSError {
-//      print("LaunchGate — Error: \(error.localizedDescription)")
-//
-//      if let recoverySuggestion = error.localizedRecoverySuggestion {
-//        print(recoverySuggestion)
-//      }
-//    }
-//
-//    return nil
-//  }
-//   --- Experiments ---
-//    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
-//        do {
-//            let decoder = JSONDecoder()
-//            let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
-//            return result
-//        } catch {
-//            print(error)
-//            return nil
-//        }
-//    }
-//    private static func parseOptionalUpdate(_ jsonData: Data) -> UpdateConfiguration? {
-//        do {
-//            let decoder = JSONDecoder()
-//            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
-//            return result
-//        } catch {
-//            print(error)
-//            return nil
-//        }
-//    }
-//    private static func parseRequiredUpdate(_ jsonData: Data) -> UpdateConfiguration? {
-//        do {
-//            let decoder = JSONDecoder()
-//            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
-//            return result
-//        } catch {
-//            print(error)
-//            return nil
-//        }
-//    }
-//  --- End of Experiments ---
-//  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
-//    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
-//    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }
-//
-//    return AlertConfiguration(message: message, blocking: blocking)
-//  }
-//
-//  private static func parseOptionalUpdate(_ json: JSON) throws -> UpdateConfiguration? {
-//    guard let version = json["optionalVersion"] as? String else { throw Error.unableToParseOptionalUpdate }
-//    guard let message = json["message"] as? String else { throw Error.unableToParseOptionalUpdate }
-//
-//    return UpdateConfiguration(version: version, message: message)
-//  }
-//
-//  private static func parseRequiredUpdate(_ json: JSON) throws -> UpdateConfiguration? {
-//    guard let version = json["minimumVersion"] as? String else { throw Error.unableToParseRequiredUpdate }
-//    guard let message = json["message"] as? String else { throw Error.unableToParseRequiredUpdate }
-//
-//    return UpdateConfiguration(version: version, message: message)
-//  }
-
 }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -9,11 +9,7 @@
 import Foundation
 
 class DefaultParser: LaunchGateParser {
-//    func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
-//        <#code#>
-//    }
     
-                                                                                                                                                                                                                                                                    
   typealias JSON = [String: AnyObject]
 
   enum Error: LaunchGateError {
@@ -35,7 +31,45 @@ class DefaultParser: LaunchGateParser {
         }
     }
     }
-    func parse(_ jsonData: Data) -> AlertConfiguration? {
+    
+
+  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+    do {
+        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
+      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
+      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
+
+      var alert: AlertConfiguration?
+      var optionalUpdate: UpdateConfiguration?
+      var requiredUpdate: UpdateConfiguration?
+
+      if let alertJSON = config["alert"] as? JSON {
+        alert = try DefaultParser.parseAlert(alertJSON)
+      }
+
+      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
+        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
+      }
+
+      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
+        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
+      }
+
+      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
+    } catch let error as DefaultParser.Error {
+      print("LaunchGate — Error: \(error)")
+    } catch let error as NSError {
+      print("LaunchGate — Error: \(error.localizedDescription)")
+
+      if let recoverySuggestion = error.localizedRecoverySuggestion {
+        print(recoverySuggestion)
+      }
+    }
+
+    return nil
+  }
+
+    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
         do {
             let decoder = JSONDecoder()
             let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
@@ -44,64 +78,46 @@ class DefaultParser: LaunchGateParser {
             print(error)
             return nil
         }
-        return nil
     }
-
-//  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
-//    do {
-//        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
-//      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
-//      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
+    private static func parseOptionalUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+        do {
+            let decoder = JSONDecoder()
+            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+            return result
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+    private static func parseRequiredUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+        do {
+            let decoder = JSONDecoder()
+            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+            return result
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+//  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
+//    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
+//    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }
 //
-//      var alert: AlertConfiguration?
-//      var optionalUpdate: UpdateConfiguration?
-//      var requiredUpdate: UpdateConfiguration?
-//
-//      if let alertJSON = config["alert"] as? JSON {
-//        alert = try DefaultParser.parseAlert(alertJSON)
-//      }
-//
-//      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
-//        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
-//      }
-//
-//      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
-//        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
-//      }
-//
-//      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
-//    } catch let error as DefaultParser.Error {
-//      print("LaunchGate — Error: \(error)")
-//    } catch let error as NSError {
-//      print("LaunchGate — Error: \(error.localizedDescription)")
-//
-//      if let recoverySuggestion = error.localizedRecoverySuggestion {
-//        print(recoverySuggestion)
-//      }
-//    }
-//
-//    return nil
+//    return AlertConfiguration(message: message, blocking: blocking)
 //  }
 
-  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
-    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
-    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }
+//  private static func parseOptionalUpdate(_ json: JSON) throws -> UpdateConfiguration? {
+//    guard let version = json["optionalVersion"] as? String else { throw Error.unableToParseOptionalUpdate }
+//    guard let message = json["message"] as? String else { throw Error.unableToParseOptionalUpdate }
+//
+//    return UpdateConfiguration(version: version, message: message)
+//  }
 
-    return AlertConfiguration(message: message, blocking: blocking)
-  }
-
-  private static func parseOptionalUpdate(_ json: JSON) throws -> UpdateConfiguration? {
-    guard let version = json["optionalVersion"] as? String else { throw Error.unableToParseOptionalUpdate }
-    guard let message = json["message"] as? String else { throw Error.unableToParseOptionalUpdate }
-
-    return UpdateConfiguration(version: version, message: message)
-  }
-
-  private static func parseRequiredUpdate(_ json: JSON) throws -> UpdateConfiguration? {
-    guard let version = json["minimumVersion"] as? String else { throw Error.unableToParseRequiredUpdate }
-    guard let message = json["message"] as? String else { throw Error.unableToParseRequiredUpdate }
-
-    return UpdateConfiguration(version: version, message: message)
-  }
+//  private static func parseRequiredUpdate(_ json: JSON) throws -> UpdateConfiguration? {
+//    guard let version = json["minimumVersion"] as? String else { throw Error.unableToParseRequiredUpdate }
+//    guard let message = json["message"] as? String else { throw Error.unableToParseRequiredUpdate }
+//
+//    return UpdateConfiguration(version: version, message: message)
+//  }
 
 }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -30,82 +30,82 @@ class DefaultParser: LaunchGateParser {
         }
     }
     }
-    func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+//    func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+//        do {
+//            let decoder = JSONDecoder()
+//            let result = try decoder.decode(LaunchGateConfiguration.self, from: jsonData)
+//            return result
+//        } catch let error {
+//            print("LaunchGate — Error: \(error)")
+//        }
+//        return nil
+//    }
+  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+    do {
+        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
+      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
+      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
+
+      var alert: AlertConfiguration?
+      var optionalUpdate: UpdateConfiguration?
+      var requiredUpdate: UpdateConfiguration?
+
+      if let alertJSON = config["alert"] as? Data {
+        alert = try DefaultParser.parseAlert(alertJSON)
+      }
+
+      if let optionalUpdateJSON = config["optionalUpdate"] as? Data {
+        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
+      }
+
+      if let requiredUpdateJSON = config["requiredUpdate"] as? Data {
+        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
+      }
+
+      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
+    } catch let error as DefaultParser.Error {
+      print("LaunchGate — Error: \(error)")
+    } catch let error as NSError {
+      print("LaunchGate — Error: \(error.localizedDescription)")
+
+      if let recoverySuggestion = error.localizedRecoverySuggestion {
+        print(recoverySuggestion)
+      }
+    }
+
+    return nil
+  }
+//   --- Experiments ---
+    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
         do {
             let decoder = JSONDecoder()
-            let result = try decoder.decode(LaunchGateConfiguration.self, from: jsonData)
+            let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
             return result
-        } catch let error {
-            print("LaunchGate — Error: \(error)")
+        } catch {
+            print(error)
+            return nil
         }
-        return nil
     }
-//  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
-//    do {
-//        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
-//      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
-//      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
-//
-//      var alert: AlertConfiguration?
-//      var optionalUpdate: UpdateConfiguration?
-//      var requiredUpdate: UpdateConfiguration?
-//
-//      if let alertJSON = config["alert"] as? JSON {
-//        alert = try DefaultParser.parseAlert(alertJSON)
-//      }
-//
-//      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
-//        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
-//      }
-//
-//      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
-//        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
-//      }
-//
-//      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
-//    } catch let error as DefaultParser.Error {
-//      print("LaunchGate — Error: \(error)")
-//    } catch let error as NSError {
-//      print("LaunchGate — Error: \(error.localizedDescription)")
-//
-//      if let recoverySuggestion = error.localizedRecoverySuggestion {
-//        print(recoverySuggestion)
-//      }
-//    }
-//
-//    return nil
-//  }
-//   --- Experiments ---
-//    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
-//        do {
-//            let decoder = JSONDecoder()
-//            let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
-//            return result
-//        } catch {
-//            print(error)
-//            return nil
-//        }
-//    }
-//    private static func parseOptionalUpdate(_ jsonData: Data) -> UpdateConfiguration? {
-//        do {
-//            let decoder = JSONDecoder()
-//            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
-//            return result
-//        } catch {
-//            print(error)
-//            return nil
-//        }
-//    }
-//    private static func parseRequiredUpdate(_ jsonData: Data) -> UpdateConfiguration? {
-//        do {
-//            let decoder = JSONDecoder()
-//            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
-//            return result
-//        } catch {
-//            print(error)
-//            return nil
-//        }
-//    }
+    private static func parseOptionalUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+        do {
+            let decoder = JSONDecoder()
+            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+            return result
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+    private static func parseRequiredUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+        do {
+            let decoder = JSONDecoder()
+            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+            return result
+        } catch {
+            print(error)
+            return nil
+        }
+    }
 //  --- End of Experiments ---
 //  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
 //    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -42,6 +42,7 @@ class DefaultParser: LaunchGateParser {
 //    }
   func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
     do {
+        print("Parsing...")
         let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
       guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
       guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
@@ -50,17 +51,26 @@ class DefaultParser: LaunchGateParser {
       var optionalUpdate: UpdateConfiguration?
       var requiredUpdate: UpdateConfiguration?
 
-      if let alertJSON = config["alert"] as? Data {
+        guard let alertJSON = config["alert"] as? Data else {
+            print("No alert")
+            return nil }
         alert = try DefaultParser.parseAlert(alertJSON)
-      }
+        print("Alert: \(alert!)")
+      
 
-      if let optionalUpdateJSON = config["optionalUpdate"] as? Data {
+      guard let optionalUpdateJSON = config["optionalUpdate"] as? Data else {
+        print("No optional update")
+        return nil }
         optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
-      }
+        print("Optional Update: \(optionalUpdate!)")
+      
 
-      if let requiredUpdateJSON = config["requiredUpdate"] as? Data {
+      guard let requiredUpdateJSON = config["requiredUpdate"] as? Data else {
+        print("No required update")
+        return nil }
         requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
-      }
+        print("Required Update: \(requiredUpdate!)")
+      
 
       return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
     } catch let error as DefaultParser.Error {

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -9,7 +9,11 @@
 import Foundation
 
 class DefaultParser: LaunchGateParser {
-
+//    func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+//        <#code#>
+//    }
+    
+                                                                                                                                                                                                                                                                    
   typealias JSON = [String: AnyObject]
 
   enum Error: LaunchGateError {
@@ -31,42 +35,53 @@ class DefaultParser: LaunchGateParser {
         }
     }
     }
-
-  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
-    do {
-        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
-      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
-      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
-
-      var alert: AlertConfiguration?
-      var optionalUpdate: UpdateConfiguration?
-      var requiredUpdate: UpdateConfiguration?
-
-      if let alertJSON = config["alert"] as? JSON {
-        alert = try DefaultParser.parseAlert(alertJSON)
-      }
-
-      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
-        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
-      }
-
-      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
-        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
-      }
-
-      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
-    } catch let error as DefaultParser.Error {
-      print("LaunchGate — Error: \(error)")
-    } catch let error as NSError {
-      print("LaunchGate — Error: \(error.localizedDescription)")
-
-      if let recoverySuggestion = error.localizedRecoverySuggestion {
-        print(recoverySuggestion)
-      }
+    func parse(_ jsonData: Data) -> AlertConfiguration? {
+        do {
+            let decoder = JSONDecoder()
+            let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
+            return result
+        } catch {
+            print(error)
+            return nil
+        }
+        return nil
     }
 
-    return nil
-  }
+//  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+//    do {
+//        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
+//      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
+//      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
+//
+//      var alert: AlertConfiguration?
+//      var optionalUpdate: UpdateConfiguration?
+//      var requiredUpdate: UpdateConfiguration?
+//
+//      if let alertJSON = config["alert"] as? JSON {
+//        alert = try DefaultParser.parseAlert(alertJSON)
+//      }
+//
+//      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
+//        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
+//      }
+//
+//      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
+//        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
+//      }
+//
+//      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
+//    } catch let error as DefaultParser.Error {
+//      print("LaunchGate — Error: \(error)")
+//    } catch let error as NSError {
+//      print("LaunchGate — Error: \(error.localizedDescription)")
+//
+//      if let recoverySuggestion = error.localizedRecoverySuggestion {
+//        print(recoverySuggestion)
+//      }
+//    }
+//
+//    return nil
+//  }
 
   private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
     guard let message = json["message"] as? String else { throw Error.unableToParseAlert }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -35,11 +35,8 @@ class DefaultParser: LaunchGateParser {
             let decoder = JSONDecoder()
             let result = try decoder.decode(LaunchGateConfiguration.self, from: jsonData)
             return result
-        } catch let error as NSError {
+        } catch let error {
             print("LaunchGate — Error: \(error.localizedDescription)")
-            if let recoverySuggestion = error.localizedRecoverySuggestion {
-                print(recoverySuggestion)
-            }
         }
         return nil
     }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -30,16 +30,16 @@ class DefaultParser: LaunchGateParser {
         }
     }
     }
-//    func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
-//        do {
-//            let decoder = JSONDecoder()
-//            let result = try decoder.decode(LaunchGateConfiguration.self, from: jsonData)
-//            return result
-//        } catch let error {
-//            print("LaunchGate — Error: \(error)")
-//        }
-//        return nil
-//    }
+    func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+        do {
+            let decoder = JSONDecoder()
+            let result = try decoder.decode(LaunchGateConfiguration.self, from: jsonData)
+            return result
+        } catch let error {
+            print("LaunchGate — Error: \(error)")
+        }
+        return nil
+    }
 //  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
 //    do {
 //        print("Parsing...")

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 class DefaultParser: LaunchGateParser {
-    
   typealias JSON = [String: AnyObject]
 
   enum Error: LaunchGateError {
@@ -31,88 +30,99 @@ class DefaultParser: LaunchGateParser {
         }
     }
     }
-    
-
-  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
-    do {
-        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
-      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
-      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
-
-      var alert: AlertConfiguration?
-      var optionalUpdate: UpdateConfiguration?
-      var requiredUpdate: UpdateConfiguration?
-
-      if let alertJSON = config["alert"] as? JSON {
-        alert = try DefaultParser.parseAlert(alertJSON)
-      }
-
-      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
-        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
-      }
-
-      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
-        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
-      }
-
-      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
-    } catch let error as DefaultParser.Error {
-      print("LaunchGate — Error: \(error)")
-    } catch let error as NSError {
-      print("LaunchGate — Error: \(error.localizedDescription)")
-
-      if let recoverySuggestion = error.localizedRecoverySuggestion {
-        print(recoverySuggestion)
-      }
-    }
-
-    return nil
-  }
-
-    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
+    func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
         do {
             let decoder = JSONDecoder()
-            let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
+            let result = try decoder.decode(LaunchGateConfiguration.self, from: jsonData)
             return result
-        } catch {
-            print(error)
-            return nil
+        } catch let error as NSError {
+            print("LaunchGate — Error: \(error.localizedDescription)")
+            if let recoverySuggestion = error.localizedRecoverySuggestion {
+                print(recoverySuggestion)
+            }
         }
+        return nil
     }
-    private static func parseOptionalUpdate(_ jsonData: Data) -> OptionalUpdate? {
-        do {
-            let decoder = JSONDecoder()
-            let result = try decoder.decode(OptionalUpdate.self, from: jsonData)
-            return result
-        } catch {
-            print(error)
-            return nil
-        }
-    }
-    private static func parseRequiredUpdate(_ jsonData: Data) -> RequiredUpdate? {
-        do {
-            let decoder = JSONDecoder()
-            let result = try decoder.decode(RequiredUpdate.self, from: jsonData)
-            return result
-        } catch {
-            print(error)
-            return nil
-        }
-    }
+//  func parse(_ jsonData: Data) -> LaunchGateConfiguration? {
+//    do {
+//        let jsonData = try JSONSerialization.jsonObject(with: jsonData, options: [])
+//      guard let json = jsonData as? JSON else { throw Error.unableToParseConfigurationObject }
+//      guard let config = json["ios"] else { throw Error.unableToParseConfigurationObject }
+//
+//      var alert: AlertConfiguration?
+//      var optionalUpdate: UpdateConfiguration?
+//      var requiredUpdate: UpdateConfiguration?
+//
+//      if let alertJSON = config["alert"] /*as? JSON*/ {
+//        alert = try DefaultParser.parseAlert(alertJSON)
+//      }
+//
+//      if let optionalUpdateJSON = config["optionalUpdate"] as? JSON {
+//        optionalUpdate = try DefaultParser.parseOptionalUpdate(optionalUpdateJSON)
+//      }
+//
+//      if let requiredUpdateJSON = config["requiredUpdate"] as? JSON {
+//        requiredUpdate = try DefaultParser.parseRequiredUpdate(requiredUpdateJSON)
+//      }
+//
+//      return LaunchGateConfiguration(alert: alert, optionalUpdate: optionalUpdate, requiredUpdate: requiredUpdate)
+//    } catch let error as DefaultParser.Error {
+//      print("LaunchGate — Error: \(error)")
+//    } catch let error as NSError {
+//      print("LaunchGate — Error: \(error.localizedDescription)")
+//
+//      if let recoverySuggestion = error.localizedRecoverySuggestion {
+//        print(recoverySuggestion)
+//      }
+//    }
+//
+//    return nil
+//  }
+//
+//    private static func parseAlert(_ jsonData: Data) -> AlertConfiguration? {
+//        do {
+//            let decoder = JSONDecoder()
+//            let result = try decoder.decode(AlertConfiguration.self, from: jsonData)
+//            return result
+//        } catch {
+//            print(error)
+//            return nil
+//        }
+//    }
+//    private static func parseOptionalUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+//        do {
+//            let decoder = JSONDecoder()
+//            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+//            return result
+//        } catch {
+//            print(error)
+//            return nil
+//        }
+//    }
+//    private static func parseRequiredUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+//        do {
+//            let decoder = JSONDecoder()
+//            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+//            return result
+//        } catch {
+//            print(error)
+//            return nil
+//        }
+//    }
 //  private static func parseAlert(_ json: JSON) throws -> AlertConfiguration? {
 //    guard let message = json["message"] as? String else { throw Error.unableToParseAlert }
 //    guard let blocking = json["blocking"] as? Bool else { throw Error.unableToParseAlert }
 //
 //    return AlertConfiguration(message: message, blocking: blocking)
 //  }
-
+//
 //  private static func parseOptionalUpdate(_ json: JSON) throws -> UpdateConfiguration? {
 //    guard let version = json["optionalVersion"] as? String else { throw Error.unableToParseOptionalUpdate }
 //    guard let message = json["message"] as? String else { throw Error.unableToParseOptionalUpdate }
 //
 //    return UpdateConfiguration(version: version, message: message)
 //  }
-
+//
 //  private static func parseRequiredUpdate(_ json: JSON) throws -> UpdateConfiguration? {
 //    guard let version = json["minimumVersion"] as? String else { throw Error.unableToParseRequiredUpdate }
 //    guard let message = json["message"] as? String else { throw Error.unableToParseRequiredUpdate }

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -79,20 +79,20 @@ class DefaultParser: LaunchGateParser {
             return nil
         }
     }
-    private static func parseOptionalUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+    private static func parseOptionalUpdate(_ jsonData: Data) -> OptionalUpdate? {
         do {
             let decoder = JSONDecoder()
-            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+            let result = try decoder.decode(OptionalUpdate.self, from: jsonData)
             return result
         } catch {
             print(error)
             return nil
         }
     }
-    private static func parseRequiredUpdate(_ jsonData: Data) -> UpdateConfiguration? {
+    private static func parseRequiredUpdate(_ jsonData: Data) -> RequiredUpdate? {
         do {
             let decoder = JSONDecoder()
-            let result = try decoder.decode(UpdateConfiguration.self, from: jsonData)
+            let result = try decoder.decode(RequiredUpdate.self, from: jsonData)
             return result
         } catch {
             print(error)

--- a/Source/DefaultParser.swift
+++ b/Source/DefaultParser.swift
@@ -36,7 +36,7 @@ class DefaultParser: LaunchGateParser {
             let result = try decoder.decode(LaunchGateConfiguration.self, from: jsonData)
             return result
         } catch let error {
-            print("LaunchGate — Error: \(error.localizedDescription)")
+            print("LaunchGate — Error: \(error)")
         }
         return nil
     }

--- a/Source/DialogManager.swift
+++ b/Source/DialogManager.swift
@@ -6,6 +6,8 @@
 //
 //
 
+// swiftlint:disable identifier_name
+
 import Foundation
 import UIKit
 

--- a/Source/DialogManager.swift
+++ b/Source/DialogManager.swift
@@ -6,8 +6,6 @@
 //
 //
 
-// swiftlint:disable identifier_name
-
 import Foundation
 import UIKit
 

--- a/Source/DialogManager.swift
+++ b/Source/DialogManager.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 protocol Dialogable {
   var message: String { get }

--- a/Source/DialogManager.swift
+++ b/Source/DialogManager.swift
@@ -40,8 +40,7 @@ class DialogManager {
   }
 
   func displayOptionalUpdateDialog(_ updateConfig: RememberableDialogSubject, updateURL: URL) {
-    let dialog = createAlertController(.optionalUpdate(updateURL: updateURL), message: updateConfig.message) 
-
+    let dialog = createAlertController(.optionalUpdate(updateURL: updateURL), message: updateConfig.message)
     displayAlertController(dialog) { () -> Void in
       Memory.remember(updateConfig)
     }

--- a/Source/DialogManager.swift
+++ b/Source/DialogManager.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 protocol Dialogable {
-  var message: String? { get }
+  var message: String { get }
 }
 
 class DialogManager {
@@ -24,7 +24,7 @@ class DialogManager {
   }
 
   func displayAlertDialog(_ alertConfig: RememberableDialogSubject, blocking: Bool) {
-    let dialog = createAlertController(.alert(blocking: blocking), message: alertConfig.message!) ///unwrap
+    let dialog = createAlertController(.alert(blocking: blocking), message: alertConfig.message)
 
     displayAlertController(dialog) { () -> Void in
       if !blocking {
@@ -34,13 +34,13 @@ class DialogManager {
   }
 
   func displayRequiredUpdateDialog(_ updateConfig: Dialogable, updateURL: URL) {
-    let dialog = createAlertController(.requiredUpdate(updateURL: updateURL), message: updateConfig.message!) ///unwrap
+    let dialog = createAlertController(.requiredUpdate(updateURL: updateURL), message: updateConfig.message)
 
     displayAlertController(dialog, completion: nil)
   }
 
   func displayOptionalUpdateDialog(_ updateConfig: RememberableDialogSubject, updateURL: URL) {
-    let dialog = createAlertController(.optionalUpdate(updateURL: updateURL), message: updateConfig.message!) ///unwrap
+    let dialog = createAlertController(.optionalUpdate(updateURL: updateURL), message: updateConfig.message) 
 
     displayAlertController(dialog) { () -> Void in
       Memory.remember(updateConfig)

--- a/Source/DialogManager.swift
+++ b/Source/DialogManager.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 protocol Dialogable {
-  var message: String { get }
+  var message: String? { get }
 }
 
 class DialogManager {
@@ -24,7 +24,7 @@ class DialogManager {
   }
 
   func displayAlertDialog(_ alertConfig: RememberableDialogSubject, blocking: Bool) {
-    let dialog = createAlertController(.alert(blocking: blocking), message: alertConfig.message)
+    let dialog = createAlertController(.alert(blocking: blocking), message: alertConfig.message!) ///unwrap
 
     displayAlertController(dialog) { () -> Void in
       if !blocking {
@@ -34,13 +34,13 @@ class DialogManager {
   }
 
   func displayRequiredUpdateDialog(_ updateConfig: Dialogable, updateURL: URL) {
-    let dialog = createAlertController(.requiredUpdate(updateURL: updateURL), message: updateConfig.message)
+    let dialog = createAlertController(.requiredUpdate(updateURL: updateURL), message: updateConfig.message!) ///unwrap
 
     displayAlertController(dialog, completion: nil)
   }
 
   func displayOptionalUpdateDialog(_ updateConfig: RememberableDialogSubject, updateURL: URL) {
-    let dialog = createAlertController(.optionalUpdate(updateURL: updateURL), message: updateConfig.message)
+    let dialog = createAlertController(.optionalUpdate(updateURL: updateURL), message: updateConfig.message!) ///unwrap
 
     displayAlertController(dialog) { () -> Void in
       Memory.remember(updateConfig)

--- a/Source/LaunchGate.swift
+++ b/Source/LaunchGate.swift
@@ -50,7 +50,7 @@ public class LaunchGate {
 
   /// Check the configuration file and perform any appropriate action.
   public func check() {
-    performCheck(RemoteFileManager(remoteFileURL: (configurationFileURL as URL)))
+    performCheck(RemoteFileManager(remoteFileURL: (configurationFileURL)))
   }
 
   // MARK: - Internal API

--- a/Source/LaunchGate.swift
+++ b/Source/LaunchGate.swift
@@ -89,7 +89,7 @@ public class LaunchGate {
       }
     } else if let alert = config.alert {
       if shouldShowAlertDialog(alert) {
-        dialogManager.displayAlertDialog(alert, blocking: alert.blocking)
+        dialogManager.displayAlertDialog(alert, blocking: alert.blocking!) ///unwrap
       }
     }
   }
@@ -102,7 +102,7 @@ public class LaunchGate {
    - Returns: `true`, if an alert dialog should be displayed; `false`, if not.
    */
   func shouldShowAlertDialog(_ alertConfig: AlertConfiguration) -> Bool {
-    return alertConfig.blocking || alertConfig.isNotRemembered()
+    return alertConfig.blocking! || alertConfig.isNotRemembered()  ///unwrap
   }
 
   /**
@@ -115,7 +115,7 @@ public class LaunchGate {
   func shouldShowOptionalUpdateDialog(_ updateConfig: UpdateConfiguration, appVersion: String) -> Bool {
     guard updateConfig.isNotRemembered() else { return false }
 
-    return appVersion < updateConfig.version
+    return appVersion < updateConfig.version! ///unwrap
   }
 
   /**
@@ -126,7 +126,7 @@ public class LaunchGate {
    - Returns: `true`, if a required update dialog should be displayed; `false`, if not.
    */
   func shouldShowRequiredUpdateDialog(_ updateConfig: UpdateConfiguration, appVersion: String) -> Bool {
-    return appVersion < updateConfig.version
+    return appVersion < updateConfig.version! ///unwrap
   }
 
   func currentAppVersion() -> String? {

--- a/Source/LaunchGate.swift
+++ b/Source/LaunchGate.swift
@@ -25,6 +25,7 @@ public class LaunchGate {
   /// Manager object for the various alert dialogs
   var dialogManager: DialogManager!
 
+    //var config: LaunchGateConfiguration!
   // MARK: - Public API
 
   /**
@@ -63,7 +64,8 @@ public class LaunchGate {
   */
   func performCheck(_ remoteFileManager: RemoteFileManager) {
     remoteFileManager.fetchRemoteFile { (jsonData) -> Void in
-      if let config = self.parser.parse(jsonData) {
+        if let config: LaunchGateConfiguration = self.parser.parse(jsonData) {
+        print("Config: \(config)")
         self.displayDialogIfNecessary(config, dialogManager: self.dialogManager)
       }
     }

--- a/Source/LaunchGate.swift
+++ b/Source/LaunchGate.swift
@@ -89,7 +89,7 @@ public class LaunchGate {
       }
     } else if let alert = config.alert {
       if shouldShowAlertDialog(alert) {
-        dialogManager.displayAlertDialog(alert, blocking: alert.blocking!) ///unwrap
+        dialogManager.displayAlertDialog(alert, blocking: alert.blocking)
       }
     }
   }
@@ -102,7 +102,7 @@ public class LaunchGate {
    - Returns: `true`, if an alert dialog should be displayed; `false`, if not.
    */
   func shouldShowAlertDialog(_ alertConfig: AlertConfiguration) -> Bool {
-    return alertConfig.blocking! || alertConfig.isNotRemembered()  ///unwrap
+    return alertConfig.blocking || alertConfig.isNotRemembered()
   }
 
   /**
@@ -115,7 +115,7 @@ public class LaunchGate {
   func shouldShowOptionalUpdateDialog(_ updateConfig: UpdateConfiguration, appVersion: String) -> Bool {
     guard updateConfig.isNotRemembered() else { return false }
 
-    return appVersion < updateConfig.version! ///unwrap
+    return appVersion < updateConfig.version
   }
 
   /**
@@ -126,7 +126,7 @@ public class LaunchGate {
    - Returns: `true`, if a required update dialog should be displayed; `false`, if not.
    */
   func shouldShowRequiredUpdateDialog(_ updateConfig: UpdateConfiguration, appVersion: String) -> Bool {
-    return appVersion < updateConfig.version! ///unwrap
+    return appVersion < updateConfig.version
   }
 
   func currentAppVersion() -> String? {

--- a/Source/LaunchGate.swift
+++ b/Source/LaunchGate.swift
@@ -65,7 +65,6 @@ public class LaunchGate {
   func performCheck(_ remoteFileManager: RemoteFileManager) {
     remoteFileManager.fetchRemoteFile { (jsonData) -> Void in
         if let config: LaunchGateConfiguration = self.parser.parse(jsonData) {
-        print("Config: \(config)")
         self.displayDialogIfNecessary(config, dialogManager: self.dialogManager)
       }
     }

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -12,36 +12,17 @@ import Foundation
 public struct LaunchGateConfiguration: Decodable {
 
   /// An `AlertConfiguration`, parsed from the configuration file.
-  var alert: AlertConfiguration
+  var alert: AlertConfiguration?
 
   /// An optional `UpdateConfiguration`, parsed from the configuration file.
-  var optionalUpdate: UpdateConfiguration
+  var optionalUpdate: UpdateConfiguration?
 
   /// A required `UpdateConfiguration`, parsed from the configuration file.
-  var requiredUpdate: UpdateConfiguration
+  var requiredUpdate: UpdateConfiguration?
     
-    struct IOSRootKeys: CodingKey {
-        var stringValue: String
-        var intValue: Int?
-        
-        init?(stringValue: String) {
-           self.stringValue = stringValue
-        }
-
-        init?(intValue: Int) {
-            self.intValue = intValue
-            self.stringValue = "\(intValue)"
-        }
-        
-        static func checkKeyName(to key: String) -> IOSRootKeys {
-            return IOSRootKeys(stringValue: key)!
-        }
-        
-        static let keyName = IOSRootKeys.changeKeyName(to: <#T##String#>)
-    }
 
   public init(from decoder: Decoder) throws {
-    let iosContainer = try decoder.container(keyedBy: IOSRootKeys.self)
+    let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
     //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
     self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)
     self.optionalUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
@@ -51,7 +32,7 @@ public struct LaunchGateConfiguration: Decodable {
     //let requiredUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .requiredUpdate)
   }
   enum IOSRootKey: CodingKey {
-    case ios
+    //case ios
     case alert
     case optionalUpdate
     case requiredUpdate

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -20,22 +20,22 @@ public struct LaunchGateConfiguration: Decodable {
   /// A required `UpdateConfiguration`, parsed from the configuration file.
   var requiredUpdate: UpdateConfiguration?
     
-  public init(from decoder: Decoder) throws {
-    let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
-    //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
-    //self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)
-    //self.optionalUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
-    //self.requiredUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .requiredUpdate)
-    //let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
-    //let optionalUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .optionalUpdate)
-    //let requiredUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .requiredUpdate)
-  }
-  enum IOSRootKey: String, CodingKey {
-    case ios
-    //case alert
-    //case optionalUpdate
-    //case requiredUpdate
-  }
+//  public init(from decoder: Decoder) throws {
+//    let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
+//    //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
+//    //self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)
+//    //self.optionalUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
+//    //self.requiredUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .requiredUpdate)
+//    //let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
+//    //let optionalUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .optionalUpdate)
+//    //let requiredUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .requiredUpdate)
+//  }
+//  enum IOSRootKey: String, CodingKey {
+//    case ios
+//    //case alert
+//    //case optionalUpdate
+//    //case requiredUpdate
+//  }
 //  enum ConfigCodingKeys: String, CodingKey {
 //    case alert
 //    case optionalUpdate

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -23,18 +23,18 @@ public struct LaunchGateConfiguration: Decodable {
   public init(from decoder: Decoder) throws {
     let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
     //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
-    self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)
-    self.optionalUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
-    self.requiredUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .requiredUpdate)
+    //self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)
+    //self.optionalUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
+    //self.requiredUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .requiredUpdate)
     //let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
     //let optionalUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .optionalUpdate)
     //let requiredUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .requiredUpdate)
   }
-  enum IOSRootKey: CodingKey {
-    //case ios
-    case alert
-    case optionalUpdate
-    case requiredUpdate
+  enum IOSRootKey: String, CodingKey {
+    case ios
+    //case alert
+    //case optionalUpdate
+    //case requiredUpdate
   }
 //  enum ConfigCodingKeys: String, CodingKey {
 //    case alert

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -20,19 +20,22 @@ public struct LaunchGateConfiguration: Decodable {
   /// A required `UpdateConfiguration`, parsed from the configuration file.
   var requiredUpdate: UpdateConfiguration?
 
-  public init(from decoder:Decoder) throws {
+  public init(from decoder: Decoder) throws {
     let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
-    let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
+    let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
+    //let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
+    //let optionalUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .optionalUpdate)
+    //let requiredUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .requiredUpdate)
   }
   enum IOSRootKey: CodingKey {
     case ios
-    case alert
-    case optionalUpdate
-    case requiredUpdate
+    //case alert
+    //case optionalUpdate
+    //case requiredUpdate
   }
-  enum ConfigCodingKeys: String, CodingKey {
-    case alert
-    case optionalUpdate
-    case requiredUpdate
-  }
+//  enum ConfigCodingKeys: String, CodingKey {
+//    case alert
+//    case optionalUpdate
+//    case requiredUpdate
+//  }
 }

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// The configuration object that should be created as the result of parsing the remote configuration file.
-public struct LaunchGateConfiguration {
+public struct LaunchGateConfiguration: Decodable {
 
   /// An `AlertConfiguration`, parsed from the configuration file.
   var alert: AlertConfiguration?

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -20,25 +20,17 @@ public struct LaunchGateConfiguration: Decodable {
   /// A required `UpdateConfiguration`, parsed from the configuration file.
   var requiredUpdate: UpdateConfiguration?
     
-//  public init(from decoder: Decoder) throws {
-//    let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
-//    //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
-//    //self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)
-//    //self.optionalUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
-//    //self.requiredUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .requiredUpdate)
-//    //let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
-//    //let optionalUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .optionalUpdate)
-//    //let requiredUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .requiredUpdate)
-//  }
-//  enum IOSRootKey: String, CodingKey {
-//    case ios
-//    //case alert
-//    //case optionalUpdate
-//    //case requiredUpdate
-//  }
-//  enum ConfigCodingKeys: String, CodingKey {
-//    case alert
-//    case optionalUpdate
-//    case requiredUpdate
-//  }
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: IOSCodingKeys.self)
+    let iosContainer = try container.nestedContainer(keyedBy: IOSCodingKeys.self, forKey: .ios)
+    alert = try iosContainer.decodeIfPresent(AlertConfiguration.self, forKey: .alert)
+    optionalUpdate = try iosContainer.decodeIfPresent(UpdateConfiguration.self, forKey: .optionalUpdate)
+    requiredUpdate = try iosContainer.decodeIfPresent(UpdateConfiguration.self, forKey: .requiredUpdate)
+  }
+  enum IOSCodingKeys: String, CodingKey {
+    case ios
+    case alert
+    case optionalUpdate
+    case requiredUpdate
+  }
 }

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -20,4 +20,19 @@ public struct LaunchGateConfiguration: Decodable {
   /// A required `UpdateConfiguration`, parsed from the configuration file.
   var requiredUpdate: UpdateConfiguration?
 
+  public init(from decoder:Decoder) throws {
+    let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
+    let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
+  }
+  enum IOSRootKey: CodingKey {
+    case ios
+    case alert
+    case optionalUpdate
+    case requiredUpdate
+  }
+  enum ConfigCodingKeys: String, CodingKey {
+    case alert
+    case optionalUpdate
+    case requiredUpdate
+  }
 }

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -12,16 +12,36 @@ import Foundation
 public struct LaunchGateConfiguration: Decodable {
 
   /// An `AlertConfiguration`, parsed from the configuration file.
-  var alert: AlertConfiguration?
+  var alert: AlertConfiguration
 
   /// An optional `UpdateConfiguration`, parsed from the configuration file.
-  var optionalUpdate: UpdateConfiguration?
+  var optionalUpdate: UpdateConfiguration
 
   /// A required `UpdateConfiguration`, parsed from the configuration file.
-  var requiredUpdate: UpdateConfiguration?
+  var requiredUpdate: UpdateConfiguration
+    
+    struct IOSRootKeys: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+        
+        init?(stringValue: String) {
+           self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) {
+            self.intValue = intValue
+            self.stringValue = "\(intValue)"
+        }
+        
+        static func checkKeyName(to key: String) -> IOSRootKeys {
+            return IOSRootKeys(stringValue: key)!
+        }
+        
+        static let keyName = IOSRootKeys.changeKeyName(to: <#T##String#>)
+    }
 
   public init(from decoder: Decoder) throws {
-    let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
+    let iosContainer = try decoder.container(keyedBy: IOSRootKeys.self)
     //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
     self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)
     self.optionalUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .optionalUpdate)

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -23,15 +23,19 @@ public struct LaunchGateConfiguration: Decodable {
   public init(from decoder: Decoder) throws {
     let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
     let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
+    
+    let alert = try ios.decode(AlertConfiguration.self, forKey: .alert)
+    let optionalUpdate = try ios.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
+    let requiredUpdate = try ios.decode(UpdateConfiguration.self, forKey: .requiredUpdate)
     //let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
     //let optionalUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .optionalUpdate)
     //let requiredUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .requiredUpdate)
   }
   enum IOSRootKey: CodingKey {
     case ios
-    //case alert
-    //case optionalUpdate
-    //case requiredUpdate
+    case alert
+    case optionalUpdate
+    case requiredUpdate
   }
 //  enum ConfigCodingKeys: String, CodingKey {
 //    case alert

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// The configuration object that should be created as the result of parsing the remote configuration file.
-public class LaunchGateConfiguration: Decodable {
+public struct LaunchGateConfiguration: Decodable {
 
   /// An `AlertConfiguration`, parsed from the configuration file.
   var alert: AlertConfiguration?
@@ -20,7 +20,7 @@ public class LaunchGateConfiguration: Decodable {
   /// A required `UpdateConfiguration`, parsed from the configuration file.
   var requiredUpdate: UpdateConfiguration?
     
-    required public init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder) throws {
     let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
     //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
     self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -22,11 +22,10 @@ public struct LaunchGateConfiguration: Decodable {
 
   public init(from decoder: Decoder) throws {
     let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
-    let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
-    
-    let alert = try ios.decode(AlertConfiguration.self, forKey: .alert)
-    let optionalUpdate = try ios.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
-    let requiredUpdate = try ios.decode(UpdateConfiguration.self, forKey: .requiredUpdate)
+    //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
+    self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)
+    self.optionalUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .optionalUpdate)
+    self.requiredUpdate = try iosContainer.decode(UpdateConfiguration.self, forKey: .requiredUpdate)
     //let alert = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .alert)
     //let optionalUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .optionalUpdate)
     //let requiredUpdate = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .requiredUpdate)

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -19,7 +19,7 @@ public struct LaunchGateConfiguration: Decodable {
 
   /// A required `UpdateConfiguration`, parsed from the configuration file.
   var requiredUpdate: UpdateConfiguration?
-    
+
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: IOSCodingKeys.self)
     let iosContainer = try container.nestedContainer(keyedBy: IOSCodingKeys.self, forKey: .ios)

--- a/Source/LaunchGateConfiguration.swift
+++ b/Source/LaunchGateConfiguration.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// The configuration object that should be created as the result of parsing the remote configuration file.
-public struct LaunchGateConfiguration: Decodable {
+public class LaunchGateConfiguration: Decodable {
 
   /// An `AlertConfiguration`, parsed from the configuration file.
   var alert: AlertConfiguration?
@@ -20,8 +20,7 @@ public struct LaunchGateConfiguration: Decodable {
   /// A required `UpdateConfiguration`, parsed from the configuration file.
   var requiredUpdate: UpdateConfiguration?
     
-
-  public init(from decoder: Decoder) throws {
+    required public init(from decoder: Decoder) throws {
     let iosContainer = try decoder.container(keyedBy: IOSRootKey.self)
     //let ios = try iosContainer.nestedContainer(keyedBy: IOSRootKey.self, forKey: .ios)
     self.alert = try iosContainer.decode(AlertConfiguration.self, forKey: .alert)

--- a/Source/RemoteFileManager.swift
+++ b/Source/RemoteFileManager.swift
@@ -23,7 +23,7 @@ class RemoteFileManager {
   func performRemoteFileRequest(_ session: URLSession, url: URL, responseHandler: @escaping (_ data: Data) -> Void) {
     let task = session.dataTask(with: url) { data, response, error in
       if let error = error {
-        print("LaunchGate — Error: \(error.localizedDescription)")
+        print("LaunchGate — Error2: \(error.localizedDescription)")
       }
       guard response != nil else {
         print("LaunchGate - Error because there is no response")

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -20,12 +20,22 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
     self.message = message
   }
   public init(from decoder: Decoder) throws {
-        let optionalKeyedContainer = try? decoder.container(keyedBy: OptionalCodingKeys.self)
-        let requiredKeyedContainer = try? decoder.container(keyedBy: RequiredCodingKeys.self)
-        version = try optionalKeyedContainer!.decode(String.self, forKey: .version)
-        message = try optionalKeyedContainer!.decode(String.self, forKey: .message)
-        version = try requiredKeyedContainer!.decode(String.self, forKey: .version)
-        message = try requiredKeyedContainer!.decode(String.self, forKey: .message)
+    let optionalKeyedContainer = try decoder.container(keyedBy: OptionalCodingKeys.self)
+    let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
+    
+    do {
+        version = try optionalKeyedContainer.decode(String.self, forKey: .version)
+        message = try optionalKeyedContainer.decode(String.self, forKey: .message)
+    } catch {
+        do {
+            version = try requiredKeyedContainer.decode(String.self, forKey: .version)
+            message = try requiredKeyedContainer.decode(String.self, forKey: .message)
+        } catch {
+            throw error
+        }
+            
+      }
+    
     }
     enum OptionalCodingKeys: String, CodingKey {
         case version = "optionalVersion"

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -21,11 +21,11 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
   }
     public init(from decoder: Decoder) throws {
         let optionalKeyedContainer = try decoder.container(keyedBy: OptionalCodingKeys.self)
-        let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
         do {
             version = try optionalKeyedContainer.decode(String.self, forKey: .version)
             message = try optionalKeyedContainer.decode(String.self, forKey: .message)
         } catch {
+            let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
             version = try requiredKeyedContainer.decode(String.self, forKey: .version)
             message = try requiredKeyedContainer.decode(String.self, forKey: .message)
         }

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
-
+    /// NOTE: 'version' name not the same; 'minimumVersion'
     let version: String
     let message: String
 

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -10,8 +10,8 @@ import Foundation
 
 public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
     /// NOTE: 'version' name not the same; 'minimumVersion'
-    let version: String
-    let message: String
+    var version: String
+    var message: String
 
   init?(version: String, message: String) {
     guard !version.isEmpty else { return nil }
@@ -20,6 +20,25 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
     self.version = version
     self.message = message
   }
+    public init(from decoder: Decoder) throws {
+        let optionalKeyedContainer = try decoder.container(keyedBy: OptionalCodingKeys.self)
+        let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
+        do {
+            version = try optionalKeyedContainer.decode(String.self, forKey: .version)
+            message = try optionalKeyedContainer.decode(String.self, forKey: .message)
+        } catch {
+            version = try requiredKeyedContainer.decode(String.self, forKey: .version)
+            message = try requiredKeyedContainer.decode(String.self, forKey: .message)
+        }
+    }
+    enum OptionalCodingKeys: String, CodingKey {
+        case version = "optionalVersion"
+        case message
+    }
+    enum RequiredCodingKeys: String, CodingKey {
+        case version = "minimumVersion"
+        case message
+    }
 
   // MARK: Rememberable Protocol Methods
 

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
+public class UpdateConfiguration: Decodable, Dialogable, Rememberable {
     var version: String
     var message: String
 
@@ -19,7 +19,7 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
     self.version = version
     self.message = message
   }
-    public init(from decoder: Decoder) throws {
+    required public init(from decoder: Decoder) throws {
         let optionalKeyedContainer = try decoder.container(keyedBy: OptionalCodingKeys.self)
         let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
         version = try optionalKeyedContainer.decode(String.self, forKey: .version)

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -21,14 +21,11 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
   }
     public init(from decoder: Decoder) throws {
         let optionalKeyedContainer = try decoder.container(keyedBy: OptionalCodingKeys.self)
-        do {
-            version = try optionalKeyedContainer.decode(String.self, forKey: .version)
-            message = try optionalKeyedContainer.decode(String.self, forKey: .message)
-        } catch {
-            let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
-            version = try requiredKeyedContainer.decode(String.self, forKey: .version)
-            message = try requiredKeyedContainer.decode(String.self, forKey: .message)
-        }
+        let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
+        version = try optionalKeyedContainer.decode(String.self, forKey: .version)
+        message = try optionalKeyedContainer.decode(String.self, forKey: .message)
+        version = try requiredKeyedContainer.decode(String.self, forKey: .version)
+        message = try requiredKeyedContainer.decode(String.self, forKey: .message)
     }
     enum OptionalCodingKeys: String, CodingKey {
         case version = "optionalVersion"

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-public struct UpdateConfiguration: Dialogable, Rememberable {
+public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
 
-  var version = ""
-  var message = ""
+    let version: String
+    let message: String
 
   init?(version: String, message: String) {
     guard !version.isEmpty else { return nil }

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
-    /// NOTE: 'version' name not the same; 'minimumVersion'
     var version: String
     var message: String
 

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
-    var version: String?
-    var message: String?
+    var version: String
+    var message: String
 
   init?(version: String, message: String) {
     guard !version.isEmpty else { return nil }
@@ -20,12 +20,12 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
     self.message = message
   }
   public init(from decoder: Decoder) throws {
-        let optionalKeyedContainer = try decoder.container(keyedBy: OptionalCodingKeys.self)
-        let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
-        version = try optionalKeyedContainer.decode(String.self, forKey: .version)
-        message = try optionalKeyedContainer.decode(String.self, forKey: .message)
-        version = try requiredKeyedContainer.decode(String.self, forKey: .version)
-        message = try requiredKeyedContainer.decode(String.self, forKey: .message)
+        let optionalKeyedContainer = try? decoder.container(keyedBy: OptionalCodingKeys.self)
+        let requiredKeyedContainer = try? decoder.container(keyedBy: RequiredCodingKeys.self)
+        version = try optionalKeyedContainer!.decode(String.self, forKey: .version)
+        message = try optionalKeyedContainer!.decode(String.self, forKey: .message)
+        version = try requiredKeyedContainer!.decode(String.self, forKey: .version)
+        message = try requiredKeyedContainer!.decode(String.self, forKey: .message)
     }
     enum OptionalCodingKeys: String, CodingKey {
         case version = "optionalVersion"
@@ -43,7 +43,7 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
   }
 
   func rememberString() -> String {
-    return self.version! ///unwrap
+    return self.version
   }
 
 }

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
-    var version: String
-    var message: String
+    var version: String?
+    var message: String?
 
   init?(version: String, message: String) {
     guard !version.isEmpty else { return nil }
@@ -43,7 +43,7 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
   }
 
   func rememberString() -> String {
-    return self.version
+    return self.version! ///unwrap
   }
 
 }

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class UpdateConfiguration: Decodable, Dialogable, Rememberable {
+public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
     var version: String
     var message: String
 
@@ -19,7 +19,7 @@ public class UpdateConfiguration: Decodable, Dialogable, Rememberable {
     self.version = version
     self.message = message
   }
-    required public init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder) throws {
         let optionalKeyedContainer = try decoder.container(keyedBy: OptionalCodingKeys.self)
         let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
         version = try optionalKeyedContainer.decode(String.self, forKey: .version)

--- a/Source/UpdateConfiguration.swift
+++ b/Source/UpdateConfiguration.swift
@@ -22,7 +22,6 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
   public init(from decoder: Decoder) throws {
     let optionalKeyedContainer = try decoder.container(keyedBy: OptionalCodingKeys.self)
     let requiredKeyedContainer = try decoder.container(keyedBy: RequiredCodingKeys.self)
-    
     do {
         version = try optionalKeyedContainer.decode(String.self, forKey: .version)
         message = try optionalKeyedContainer.decode(String.self, forKey: .message)
@@ -33,9 +32,7 @@ public struct UpdateConfiguration: Decodable, Dialogable, Rememberable {
         } catch {
             throw error
         }
-            
       }
-    
     }
     enum OptionalCodingKeys: String, CodingKey {
         case version = "optionalVersion"


### PR DESCRIPTION
## What you did :question:
- Updated `parse` method: uses JSONDecoder instead of JSONSerialization

## How you did it :white_check_mark:
- Made model classes (LaunchGateConfiguration, UpdateConfiguration, and AlertConfiguration) conform to Decodable
- Manually decoded the LaunchGateConfiguration and UpdateConfiguration classes with decoder initializers
- Rewrote `parse` method to use JSONDecoder in order to parse the root object (LaunchGateConfiguration type) and its nested objects (UpdateConfiguration and AlertConfiguration)
- Removed error enum, since Decodable classes will throw the appropriate errors

## How to test it :microscope:
- Build and run the Example app
- An alert should pop up that reads "An update is required to continue using this app."


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-11-16 at 09 35 01](https://user-images.githubusercontent.com/8409475/48627665-237a3800-e983-11e8-8c65-f2ca091b0a50.png)
